### PR TITLE
Fix: Usage of non existing Router method

### DIFF
--- a/src/containers/App/partials/AppSearchDrawer.js
+++ b/src/containers/App/partials/AppSearchDrawer.js
@@ -42,7 +42,7 @@ const AppSearchDrawer = React.memo(function AppSearchDrawer(props) {
 
   const handleSubmit = React.useCallback((event) => {
     event.preventDefault()
-    Router.pushRoute(`/search/${valueRef.current}`).then(() => window.scrollTo(0, 0))
+    Router.push(`/search/${valueRef.current}`).then(() => window.scrollTo(0, 0))
   }, [])
 
   const submitButton = (


### PR DESCRIPTION
Replaces `Router.pushRoute` with `Router.push`.